### PR TITLE
Fix Docker base image version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ FROM sandreas/ffmpeg:5.0.1-3 as ffmpeg
 FROM sandreas/mp4v2:2.1.1 as mp4v2
 FROM sandreas/fdkaac:2.0.1 as fdkaac
 
-FROM python:3.11-alpine
+FROM python:3.11-alpine3.15
 ENV WORKDIR /mnt/
 ENV M4BTOOL_TMP_DIR /tmp/m4b-tool/
 


### PR DESCRIPTION
The base container, python3.11-alpine, has let the alpine version drift such that packages like php8-cli no longer exist, so the build fails. We have to pin the alpine version to, e.g, 3.15, to maintain compatibility.

Technically the m4b-tool Dockerfile that we're attempting to emulate is even older than that, it uses Alpine 3.14, but there is no python3.11-alpine3.14 image, and it looks like 3.15 is still compatible.
