### PR TITLE
chore(release): v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.5.1](https://github.com/djdembeck/m4b-merge/compare/v0.5.0...v0.5.1) (2023-02-24)
+
+
+### Bug Fixes
+
+* **merge:** :bug: incorrect dict key ([54d4a8b](https://github.com/djdembeck/m4b-merge/commit/54d4a8b259a0486ace02f69264aeacd7e224f26f))
+
 ## [0.5.0](https://github.com/djdembeck/m4b-merge/compare/v0.4.11...v0.5.0) (2023-02-24)
 
 

--- a/src/m4b_merge/m4b_helper.py
+++ b/src/m4b_merge/m4b_helper.py
@@ -186,7 +186,7 @@ class M4bMerge:
         """
         # First we need to replace the terms with actual data
         # ASIN
-        self.replace_tag('asin', self.metadata.asin)
+        self.replace_tag('asin', self.metadata['asin'])
         # Author
         self.replace_tag('author', self.path_author)
         # Narrator


### PR DESCRIPTION

### [0.5.1](https://github.com/djdembeck/m4b-merge/compare/v0.5.0...v0.5.1) (2023-02-24)


### Bug Fixes

* **merge:** :bug: incorrect dict key ([54d4a8b](https://github.com/djdembeck/m4b-merge/commit/54d4a8b259a0486ace02f69264aeacd7e224f26f))
