### PR TITLE
Added flag for using audible.com as chapter metadata source

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ optional arguments:
                         Output directory
   -p PATH_FORMAT, --path_format PATH_FORMAT
                         Structure of output path/naming.Supported terms: author, narrator, series_name, series_position, subtitle, title, year
+  --use_audible_chapter_api
+                        Sources the chapter information directly from audible.com.                        
 
 ```
 

--- a/src/m4b_merge/__main__.py
+++ b/src/m4b_merge/__main__.py
@@ -25,7 +25,7 @@ def run_all(input_path):
 
     # Create BookData object from asin response
     aud = audible_helper.BookData(asin)
-    metadata = aud.fetch_api_data(config.api_url)
+    metadata = aud.fetch_api_data(config.api_url, config.use_audible_chapter_api)
     chapters = aud.get_chapters()
 
     # Process metadata and run components to merge files
@@ -39,6 +39,9 @@ def validate_args(args):
         config.api_url = args.api_url
     else:
         config.api_url = "https://api.audnex.us"
+    # Use Audible API for Chapter Infos
+    if args.use_audible_chapter_api:
+        config.use_audible_chapter_api = True
     # Completed Directory
     if args.completed_directory:
         config.junk_dir = args.completed_directory
@@ -84,6 +87,8 @@ def validate_args(args):
     logging.debug(f'Using CPU cores: {config.num_cpus}')
     logging.debug(f'Using output path: {config.output}')
     logging.debug(f'Using output format: {config.path_format}')
+    logging.debug(f'Using Audible Chapter API: {config.use_audible_chapter_api}')    
+
     # Inputs
     # Last to be checked
     if args.inputs:
@@ -143,6 +148,12 @@ def main():
         ),
         type=str
     )
+    parser.add_argument(
+        "--use_audible_chapter_api",
+        help="Uses the Audible API for gathering chapter information",
+        action="store_true",
+        required=False
+    )    
 
     validate_args(parser.parse_args())
 

--- a/src/m4b_merge/__main__.py
+++ b/src/m4b_merge/__main__.py
@@ -42,6 +42,8 @@ def validate_args(args):
     # Use Audible API for Chapter Infos
     if args.use_audible_chapter_api:
         config.use_audible_chapter_api = True
+    else:
+        config.use_audible_chapter_api = False
     # Completed Directory
     if args.completed_directory:
         config.junk_dir = args.completed_directory


### PR DESCRIPTION
Thanks for writing this software! However, I noticed a small flaw in the data that audnexus gets. Since the length of an audiobook file differs with the encoding, the quality has to be taken into account when gathering data about the chapter length from audible. I realized this when I noticed that the chapters were offset by a tiny amount, compared to the same audible app. You can see this for yourself by making two different requests to the audible API, one without specifying the “quality” parameter and the other being set to "High":

For example, [https://api.audible.com/1.0/content/1529396409/metadata?response_groups=chapter_info&quality=High](https://api.audible.com/1.0/content/1529396409/metadata?response_groups=chapter_info&quality=High) gets you a runtime length of 23768703 milliseconds (06:36:08.703), while [https://api.audible.com/1.0/content/1529396409/metadata?response_groups=chapter_info](https://api.audible.com/1.0/content/1529396409/metadata?response_groups=chapter_info)  gets you 23769795 milliseconds (06:36:09.795) (which is the default request audnexus presumably used for their database). 

The same effect can also be seen when looking at the start_offset_ms field, which explains why an ordinary, uncompressed audible .m4b file will have their chapter marks a little bit too late. In the example above, the timestamp for chapter 16 starts exactly 1.095 seconds too late, cutting off the speaker's voice. This gets more noticeable the longer the file gets, i.e., the later chapters are offset by a larger amount than the earlier ones, which is why I didn’t notice this issue when I first started processing my audiobooks.

Sadly, audnexus doesn’t appear to have an option to change the version of the audiobook info that the API returns, which the audible API does. I made a first implementation that allows for an additional flag, which, when active, will use the audible API when it comes to chapterizing data. 

However, I would also think it would be prudent to switch to the audible API entirely, since the program depends on a correct ASIN anyway and the highest quality version of the audiobook file is arguably the most desirable one. This would thankfully be very easy, since the responses of both APIs are very similarly structured. 

What do you think?