### PR TITLE
Add flag to use chapters offset for non audible files tagged using audible api

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ optional arguments:
                         Output directory
   -p PATH_FORMAT, --path_format PATH_FORMAT
                         Structure of output path/naming.Supported terms: author, narrator, series_name, series_position, subtitle, title, year
+  --chapters-offset     For files not from Audible, adjust chapters to offset according to brandIntroDurationMs
 
 ```
 

--- a/src/m4b_merge/__main__.py
+++ b/src/m4b_merge/__main__.py
@@ -26,7 +26,7 @@ def run_all(input_path):
     # Create BookData object from asin response
     aud = audible_helper.BookData(asin)
     metadata = aud.fetch_api_data(config.api_url)
-    chapters = aud.get_chapters()
+    chapters = aud.get_chapters(config.use_chapters_offset)
 
     # Process metadata and run components to merge files
     m4b = m4b_helper.M4bMerge(input_data, metadata, input_path, chapters)
@@ -39,6 +39,11 @@ def validate_args(args):
         config.api_url = args.api_url
     else:
         config.api_url = "https://api.audnex.us"
+    # Chapter offset for non audible files
+    if args.chapters_offset:
+        config.use_chapters_offset = True
+    else:
+        config.use_chapters_offset = False
     # Completed Directory
     if args.completed_directory:
         config.junk_dir = args.completed_directory
@@ -84,6 +89,7 @@ def validate_args(args):
     logging.debug(f'Using CPU cores: {config.num_cpus}')
     logging.debug(f'Using output path: {config.output}')
     logging.debug(f'Using output format: {config.path_format}')
+    logging.debug(f'Using chapters offset: {config.use_chapters_offset}')
     # Inputs
     # Last to be checked
     if args.inputs:
@@ -142,6 +148,12 @@ def main():
             "subtitle, title, year"
         ),
         type=str
+    )
+    parser.add_argument(
+        "--chapters-offset",
+        help="For files not from Audible, adjust chapters to offset according to brandIntroDurationMs",
+        action="store_true",
+        required=False
     )
 
     validate_args(parser.parse_args())

--- a/src/m4b_merge/audible_helper.py
+++ b/src/m4b_merge/audible_helper.py
@@ -37,10 +37,13 @@ class BookData:
 
         return timestamp + '.' + '000'
 
-    def get_chapters(self):
+    def get_chapters(self, use_chapters_offset):
         # Select chapter data from json response
         chapter_info = self.metadata_dict['chapter_info']
-
+        if use_chapters_offset:
+            offset = chapter_info.get('brandIntroDurationMs', 0)
+        else:
+            offset = 0    
         # Only use Audible chapters if tagged as accurate
         if 'isAccurate' in chapter_info and chapter_info['isAccurate'] is True:
             chapter_output = []
@@ -54,8 +57,11 @@ class BookData:
             )
 
             # Append each chapter to array
-            for chapter in chapter_info['chapters']:
-                chap_start = self.ms_to_timestamp(chapter['startOffsetMs'])
+            for index, chapter in enumerate(chapter_info['chapters']):
+                if index == 0:
+                    chap_start = self.ms_to_timestamp(chapter['startOffsetMs'])
+                else:
+                    chap_start = self.ms_to_timestamp(chapter['startOffsetMs'] - offset)
                 # Starting chapter title data
                 chapter_title = chapter['title']
                 chapter_output.append(


### PR DESCRIPTION
I would like to tag m4a files I got outside of audible with audible metadata, particularly the chapters markers. Your software has been great at this, however the chapter markers are not accurate due to the audible branding "This is audible" added before the start of each book. 

Luckily, audnexus does return this metadata 
`"brandIntroDurationMs":2043,"brandOutroDurationMs":5061,"chapters":`
I believe in my testing, only brandIntroDurationMs is useful to offset each chapter's start time. 

I've created a feature flag for this `chapter-offset`, and tested it briefly and it worked as intended.  
I'm very new at python and contributing, appreciate if you can check and let me know. 
