### PR TITLE
If junk_dir is not set, do not perform post-process move

### DIFF
--- a/src/m4b_merge/m4b_helper.py
+++ b/src/m4b_merge/m4b_helper.py
@@ -117,11 +117,12 @@ class M4bMerge:
             exist_ok=True
         )
 
-        # Folder to move original input into
-        Path(config.junk_dir).mkdir(
-            parents=True,
-            exist_ok=True
-        )
+        if config.junk_dir:
+            # Folder to move original input into
+            Path(config.junk_dir).mkdir(
+                parents=True,
+                exist_ok=True
+            )
 
         # Array for argument use
         # main metadata args
@@ -485,6 +486,7 @@ class M4bMerge:
         subprocess.call(args, shell=False)
 
     def move_completed_input(self):
+        if not config.junk_dir: return
         # Cleanup cover file
         if self.cover_path:
             os.remove(self.cover_path)


### PR DESCRIPTION
Allow disabling the move after import in bragibooks. This will pair with a PR in bragibooks which will allow a blank junk_dir.

This is to stop bragibooks moving files from outside my download directory where they are managed by my download client.