### PR TITLE
ci(docker): comma-separate flavor options to honor latest=false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # No suffix on PRs or develop (single-arch preview image at canonical
-          flavor: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'suffix=-amd64;latest=false' || 'latest=false' }}
+          flavor: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'suffix=-amd64,latest=false' || 'latest=false' }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -170,7 +170,7 @@ jobs:
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          flavor: suffix=-arm64;latest=false
+          flavor: suffix=-arm64,latest=false
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          flavor: suffix=-${{ matrix.suffix }};latest=false
+          flavor: suffix=-${{ matrix.suffix }},latest=false
           tags: |
             type=raw,value=${{ env.TAG_NAME }}
             type=semver,pattern={{version}},value=${{ env.TAG_NAME }}


### PR DESCRIPTION
## What
`docker-metadata-action` v6.2.0 parses the `flavor` input as **CSV** and for each field does `field.split('=')` keeping only the 2nd element as the value.

The pipeline used `flavor: suffix=-<arch>;latest=false`. Because there is no comma, the whole string is **one CSV field**; `split('=')` yields `["suffix", "-arm64;latest", "false"]`, so:
- `suffix` becomes `"-arm64;latest"` (polluted),
- the `latest=false` option is **silently dropped** → `latest` stays `auto`.

## Symptom
On every `main` push, the per-arch jobs then emit **only** the `-latest` variants (`sha-<sha>-arm64-latest`) and never the base tags (`sha-<sha>-arm64`) that `docker-manifest` derives by appending `-amd64`/`-arm64`. `main` assembly succeeded purely because stale non-`-latest` `main-amd64`/`main-arm64` still existed from an older run. The commit-specific `sha-<sha>` manifest can never be built:

```
ERROR: ghcr.io/djdembeck/m4b-merge:sha-88c79b1-arm64: not found
```

Verified against the pinned action's `src/flavor.ts`:
- `suffix=-arm64;latest=false`  → `{latest:"auto", suffix:"-arm64;latest"}`
- `suffix=-arm64,latest=false`  → `{latest:"false", suffix:"-arm64"}`

## Fix
Comma-separate the options in the three affected flavors (ci.yml amd64/arm64, release.yml matrix) so `latest=false` is actually parsed. Files-only `.github` change → no version bump (release-please excludes `.github`).